### PR TITLE
feat(functions): bump to 0.1.10 for adding SB_PUBLISHABLE_KEY env for functions

### DIFF
--- a/charts/supabase/Chart.yaml
+++ b/charts/supabase/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templaWhates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 0.1.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -87,6 +87,16 @@ spec:
                   name: {{ include "supabase.secret.jwt" . }}
                   key: secret
                   {{- end }}
+            - name: SB_PUBLISHABLE_KEY
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.secret.jwt.secretRef }}
+                  name: {{ .Values.secret.jwt.secretRef }}
+                  key: {{ .Values.secret.jwt.secretRefKey.publishableKey |  default "publishableKey" }}
+                  {{- else }}
+                  name: {{ include "supabase.secret.jwt" . }}
+                  key: publishableKey
+                  {{- end }}
             - name: SUPABASE_ANON_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -26,6 +26,7 @@ secret:
     # override secret keys for existing secret refs
     secretRefKey:
       anonKey: anonKey
+      publishableKey: publishableKey
       serviceKey: serviceKey
       secret: secret
   # database credentials


### PR DESCRIPTION
cf https://github.com/orgs/supabase/discussions/29260

Applying this new key only to the functions deployment for now, but could be
used to replace the anonKey on other deployments later - to revisit this upon
supabase major upgrade.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
